### PR TITLE
Add: 서브홈 ver2 / 리스트 페이지 레이아웃, 기능 구현 완료

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -13,7 +13,7 @@ const Router = () => {
         <Route path="/" element={<SubHome />} />
         <Route path="/list" element={<ListPage />} />
         <Route path="/postWritePage" element={<PostWritePage />} />
-        <Route path="/detail" element={<CardDetailPage />} />
+        <Route path="/detail/:id" element={<CardDetailPage />} />
         <Route path="/login" element={<Login />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/CardSubHome/CardSubHome.module.scss
+++ b/src/components/CardSubHome/CardSubHome.module.scss
@@ -1,9 +1,10 @@
 .categoryList {
-  .topTitle {
-    margin-top: 5vh;
+  .btnWrapper {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
+    margin-top: 3em;
     .introduce {
+      cursor: pointer;
       width: 10rem;
       background-color: #ff6d6a;
       border-radius: 100px;
@@ -15,19 +16,27 @@
         display: block;
       }
     }
+  }
+  .topTitle {
+    margin-top: 5vh;
+    display: flex;
+    justify-content: space-between;
     .titleCate {
       padding-left: 10px;
+      font-weight: 700;
     }
     .titleAll {
       padding-right: 10px;
       a {
         color: #131a24;
+        font-weight: 500;
       }
     }
   }
   .buttonWrap {
     margin-top: 5vh;
     .cateBtn {
+      cursor: pointer;
       margin-left: 3px;
       margin-right: 3px;
       background-color: antiquewhite;
@@ -40,6 +49,9 @@
   .cateTitle {
     margin-top: 5vh;
     padding-left: 10px;
+    font-weight: 700;
+    color: #ff6d6a;
+    font-size: 1.2em;
   }
 }
 
@@ -50,9 +62,9 @@
   grid-column-gap: 2rem;
   padding-top: 5vh;
   .cardContainer {
+    cursor: pointer;
     width: 22%;
     border-radius: 25px;
-    // border: #5bb684 2px solid;
     .imageContainer {
       display: flex;
       height: 8rem;
@@ -64,7 +76,6 @@
         height: 100%;
         border-radius: 25px 25px 0 0;
         object-fit: cover;
-        // padding: 7px;
       }
     }
     .contentContainer {
@@ -79,6 +90,7 @@
       .companyName {
         margin-top: 14px;
         text-align: center;
+        font-weight: 600;
       }
       .companyDesc {
         margin-top: 14px;
@@ -87,22 +99,8 @@
     }
   }
 }
-// .pagenation {
-//   display: flex;
-//   gap: 1rem;
-//   overflow: hidden;
-//   .moveBtn {
-//     z-index: 999;
-//   }
-//   .pageList {
-//     display: flex;
-//     gap: 2rem;
-//     width: 5.4rem;
-
-//     .pageItem {
-//       width: 1rem;
-//       height: 1rem;
-//       cursor: pointer;
-//     }
-//   }
-// }
+.pagination {
+  margin-top: 3.5em;
+  display: flex;
+  justify-content: center;
+}

--- a/src/components/CardSubHome/CardSubHome.tsx
+++ b/src/components/CardSubHome/CardSubHome.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import css from './CardSubHome.module.scss';
 import { Pagination } from '@mui/material';
 
@@ -13,12 +13,7 @@ function CardSubHome() {
   }, []);
 
   const [categoryText, setCategoryText] = useState('');
-  const handleButtonValue = (e: React.ChangeEvent<any>) => {
-    setCategoryText(e.target.textContent);
-  };
   const [isAccess, setIsAccess] = useState(false);
-  // const token: string | null = localStorage.getItem('token');
-  // const requestHeaders: HeadersInit = new Headers();
   const requestHeaders: HeadersInit = new Headers();
   requestHeaders.set('Content-Type', 'application/json');
   requestHeaders.set(
@@ -28,9 +23,6 @@ function CardSubHome() {
       ?.slice(1, localStorage.getItem('token')!.length - 1) || 'no token'
   );
   useEffect(() => {
-    // if (token) {
-    //   requestHeaders.set('token', token);
-    // }
     fetch('http://localhost:8000/user/checkauth', {
       headers: requestHeaders,
     })
@@ -40,35 +32,24 @@ function CardSubHome() {
       });
   });
 
-  const handleIntroduce = () => {
-    // if (token) {
-    //   requestHeaders.set('token', token);
-    // }
-    // fetch('http://localhost:8000/user/checkauth', {
-    //   headers: requestHeaders,
-    // })
-    //   .then(res => res.json())
-    //   .then(result => {
-    //     setIsAccess(result.write_permission);
-    //   });
-  };
-
   const handleCategory = (e: React.MouseEvent<HTMLElement>) => {
-    const element = e.currentTarget;
-    fetch(`http://localhost:8000/subhome/category?category_id=${element.id}`)
+    const category = e.currentTarget;
+    fetch(`http://localhost:8000/subhome/category?category_id=${category.id}`)
       .then(res => res.json())
       .then(result => {
         setCompanyCard(result);
       });
+    const target = e.target as Element;
+    setCategoryText(target.innerHTML);
   };
 
-  // const navigate = useNavigate();
-  // const moveDetail = () => {
-  //   navigate(`/detail/${feed_id}`);
-  // };
+  const navigate = useNavigate();
+  const moveDetail = (e: React.MouseEvent<HTMLElement>) => {
+    const target = e.currentTarget as Element;
+    navigate(`/detail/${target.id}`);
+  };
 
-  const [currPage, setCurrPage] = useState(''); //전체 페이지 수
-  console.log('페이지', `http://localhost:8000/feedlist?page=${currPage}`);
+  const [currPage, setCurrPage] = useState('');
   const [totalPages, setTotalPages] = useState(0);
   useEffect(() => {
     fetch(`http://localhost:8000/feedlist?page=${currPage}`, {
@@ -84,15 +65,18 @@ function CardSubHome() {
   const handlePagination = (e: React.ChangeEvent<any>) => {
     setCurrPage(e.target.textContent);
   };
+
   return (
     <>
       <div className={css.categoryList}>
-        <div className={css.topTitle}>
+        <div className={css.btnWrapper}>
           {isAccess === undefined && (
-            <button className={css.introduce} onClick={handleIntroduce}>
+            <button className={css.introduce}>
               <Link to="/postWritePage">우리 회사 소개하기</Link>
             </button>
           )}
+        </div>
+        <div className={css.topTitle}>
           <p className={css.titleCate}>업종별 살펴보기</p>
           <p className={css.titleAll}>
             <Link to="/list">전체 보기</Link>
@@ -105,13 +89,12 @@ function CardSubHome() {
               key={category_id}
               id={category_id}
               onClick={handleCategory}
-              // onChange={handleButtonValue}
             >
               {category}
             </button>
           ))}
         </div>
-        {/* <p className={css.cateTitle}>{categoryText}</p> */}
+        <p className={css.cateTitle}>{categoryText}</p>
       </div>
       <div className={css.cardWrap}>
         {companyCard.map(
@@ -119,7 +102,8 @@ function CardSubHome() {
             <div
               className={css.cardContainer}
               key={feed_id}
-              // onClick={moveDetail}
+              id={feed_id}
+              onClick={moveDetail}
             >
               <div className={css.imageContainer}>
                 <img
@@ -137,7 +121,11 @@ function CardSubHome() {
         )}
       </div>
       {totalPages !== 0 && (
-        <Pagination count={totalPages} onChange={handlePagination} />
+        <Pagination
+          className={css.pagination}
+          count={totalPages}
+          onChange={handlePagination}
+        />
       )}
     </>
   );

--- a/src/components/CompanyList/CompanyList.module.scss
+++ b/src/components/CompanyList/CompanyList.module.scss
@@ -1,9 +1,15 @@
 .categoryList {
   .topTitle {
-    margin-top: 5vh;
+    margin-top: 1vh;
     display: flex;
     justify-content: space-between;
+    .titleAll {
+      padding-right: 10px;
+      font-weight: 700;
+      font-size: 1.5rem;
+    }
     .introduce {
+      cursor: pointer;
       width: 10rem;
       background-color: #ff6d6a;
       border-radius: 100px;
@@ -18,9 +24,6 @@
     .titleCate {
       padding-left: 10px;
     }
-    .titleAll {
-      padding-right: 10px;
-    }
   }
   .buttonWrap {
     margin-top: 5vh;
@@ -29,6 +32,7 @@
       padding-left: 10px;
     }
     .cateBtn {
+      cursor: pointer;
       margin-left: 2px;
       margin-right: 2px;
       background-color: antiquewhite;
@@ -41,15 +45,24 @@
   .cateTitle {
     margin-top: 5vh;
     padding-left: 10px;
+    margin-bottom: 1.5vh;
+  }
+  .title {
+    color: #ff6d6a;
+    font-weight: 500;
+    margin-top: 2em;
+    font-size: 1.2em;
+    margin-left: 2rem;
   }
 }
 
 .cardWrap {
+  cursor: pointer;
   display: flex;
   flex-wrap: wrap;
   grid-row-gap: 2rem;
   grid-column-gap: 2rem;
-  padding-top: 5vh;
+  padding-top: 9vh;
   .cardContainer {
     width: 22%;
     border-radius: 25px;
@@ -78,6 +91,7 @@
       .companyName {
         margin-top: 14px;
         text-align: center;
+        font-weight: 600;
       }
       .companyDesc {
         margin-top: 14px;
@@ -85,4 +99,9 @@
       }
     }
   }
+}
+.pagination {
+  margin-top: 3.5em;
+  display: flex;
+  justify-content: center;
 }

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -8,11 +8,12 @@
   padding-left: 4rem;
 
   & h1 {
-    // align-self: center;
-    margin-top: 10px;
-    font: {
-      size: 2em;
-      weight: 700;
+    display: flex;
+    align-items: center;
+    a {
+      font-size: 2rem;
+      font-weight: 700;
+      color: black;
     }
   }
   button {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import css from './Header.module.scss';
-import { Link } from 'react-router-dom';
 
 const Header = () => {
   return (
     <header className={css.headerContainer}>
-      <h1>FASTFIVE</h1>
+      <h1>
+        <Link to="/">FASTFIVE</Link>
+      </h1>
       <button>
         <Link to="/login">로그인</Link>
       </button>


### PR DESCRIPTION
## :: 최근 작업 주제

- [x] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 서브홈 ver2 / 리스트 페이지 레이아웃, 기능 구현 완료

<br />

## :: 구현 사항 설명

1. 상단 필터 카테고리
- 지역, 카테고리 레이아웃 구현
- 클릭시, 해당 카테고리를 가지고 있는 회사가 하단에 나타남
2. 우리 회사 소개하기
- 우리 회사 소개하기 페이지로 이동
3. 페이지네이션
- 하단의 페이지 숫자를 클릭하면, 일정한 수의 카드를 리스트 형태로 표시
4. 전체 보기 버튼 클릭시 리스트 페이지로 이동
<br />
<img width="1415" alt="스크린샷 2022-12-22 오전 8 41 28" src="https://user-images.githubusercontent.com/107600263/209024050-e6af49ec-a9dd-41b3-bcd8-17ce0ecfc886.png">
<br />



## :: 성장 포인트

- 페이지네이션을 위한 백엔드와의 통신
- 카테고리 필터를 적용시키기 위해 로직 구현
- 선택한 버튼의 값을 불러와서 다른 위치에서 텍스트로 구현 

<br />

## :: 기타 질문 및 특이 사항