### PR TITLE
Fix : 상세페이지 안뜨는 현상 수정

### DIFF
--- a/src/pages/CardDetailPage/CardDetailPage.module.scss
+++ b/src/pages/CardDetailPage/CardDetailPage.module.scss
@@ -107,7 +107,11 @@
       .contactInfo {
         padding-bottom: 0;
         .copyEmail {
+          margin-right: 0.5rem;
           cursor: pointer;
+        }
+        .contact {
+          margin-right: 0.5rem;
         }
       }
       .delete {

--- a/src/pages/CardDetailPage/CardDetailPage.tsx
+++ b/src/pages/CardDetailPage/CardDetailPage.tsx
@@ -59,10 +59,10 @@ const CardDetailPage = () => {
     })
       .then(response => response.json())
       .then(json => {
-        setPostInfo(json[0]);
-        setFieldList(json[0].field_name);
-        setWriterId(json[0].user_id);
-        setEmail(json[0].contact);
+        setPostInfo(json);
+        setFieldList(json.field_name);
+        setWriterId(json.user_id);
+        setEmail(json.contact);
       });
   }, []);
 
@@ -129,7 +129,7 @@ const CardDetailPage = () => {
           {isModalOn && (
             <div className={css.modalBg}>
               <div className={css.modalMain}>
-                <p className={css.copyMessage}>이메일이 복사되었습니다.</p>
+                <p className={css.copyMessage}>복사되었습니다.</p>
               </div>
             </div>
           )}
@@ -207,14 +207,27 @@ const CardDetailPage = () => {
               </div>
               <div className={css.gridItem}>
                 <p className={css.contactInfo}>
-                  <span className={css.copyEmail} onClick={copyEmailInhttp}>
+                  <span
+                    className={
+                      postInfo?.contact.includes('.')
+                        ? css.copyEmail
+                        : css.contact
+                    }
+                    onClick={
+                      postInfo?.contact.includes('.')
+                        ? copyEmailInhttp
+                        : undefined
+                    }
+                  >
                     {postInfo?.contact}
                   </span>
                   ({postInfo?.user_title})
                 </p>
-                <span className={css.alertMessage}>
-                  이메일을 클릭하면 복사됩니다.
-                </span>
+                {postInfo?.contact.includes('.') && (
+                  <span className={css.alertMessage}>
+                    이메일을 클릭하면 복사됩니다.
+                  </span>
+                )}
               </div>
               <div className={`${css.gridItem} ${css.infoContent}`}>
                 <p>{postInfo?.detail_introduction}</p>


### PR DESCRIPTION
## :: 최근 작업 주제

- [ ] 레이아웃 구현
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 상세페이지가 뜨지 않는 현상을 수정합니다.
<br />

## :: 구현 사항 설명

1. 상세페이지 안뜨는 현상 수정
- fetch에서 json[0]을 json으로 수정(백엔드 로직 수정에 의한 변경)

2. 추가 수정) 연락처 정보에 이메일 없을 시 '이메일을 클릭하면 복사됩니다'문구 안뜨게 수정
